### PR TITLE
Fix Score bug where score doesn't update after 1st iteration

### DIFF
--- a/main.js
+++ b/main.js
@@ -495,6 +495,7 @@ function reset() {
   flag = 0;
   position = 0;
   score = 0;
+  baseHeight = 0;
 
   base = new Base();
   player = new Player();


### PR DESCRIPTION
Fixes a bug where the baseHeight global variable is not reset between iterations, so on run2 it will not update the score. 
